### PR TITLE
Tests to check if db connections closed

### DIFF
--- a/cases/close-connections/acceptance.suite.yml
+++ b/cases/close-connections/acceptance.suite.yml
@@ -1,0 +1,8 @@
+actor: AcceptanceTester
+modules:
+  enabled:
+    - Yii2
+    - Asserts
+  config:
+    Yii2:
+      cleanup: false

--- a/cases/close-connections/acceptance/FirstCest.php
+++ b/cases/close-connections/acceptance/FirstCest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace tests\acceptance;
+
+use tests\AcceptanceTester;
+use tests\fixtures\EmptyFixture;
+use tests\helpers\SqlliteHelper;
+
+class FirstCest
+{
+    public function _fixtures()
+    {
+        return [
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ];
+    }
+
+    public function NoConnections1(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function NoConnections2(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function NoConnections3(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+}

--- a/cases/close-connections/acceptance/SecondCest.php
+++ b/cases/close-connections/acceptance/SecondCest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace tests\acceptance;
+
+use tests\AcceptanceTester;
+use tests\fixtures\EmptyFixture;
+use tests\helpers\SqlliteHelper;
+
+class SecondCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+    }
+
+    public function OnlyOneConnection1(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection2(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection3(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+}

--- a/cases/close-connections/acceptance/ThirdCest.php
+++ b/cases/close-connections/acceptance/ThirdCest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace tests\acceptance;
+
+use tests\AcceptanceTester;
+use tests\fixtures\EmptyFixture;
+use tests\helpers\SqlliteHelper;
+
+class ThirdCest
+{
+    public function NoConnections1(AcceptanceTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function OnlyOneConnection2(AcceptanceTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection3(AcceptanceTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+}

--- a/cases/close-connections/codeception.yml
+++ b/cases/close-connections/codeception.yml
@@ -1,0 +1,11 @@
+paths:
+    tests: .
+    log: ../../_output
+    data: _data
+    support: ../../_support
+namespace: tests\
+modules:
+  config:
+    Yii2:
+      configFile: config.php
+      transaction: false

--- a/cases/close-connections/config.php
+++ b/cases/close-connections/config.php
@@ -1,0 +1,12 @@
+<?php
+return [
+    'id' => 'Simple',
+    'basePath' => __DIR__,
+
+    'components' => [
+        'db' => [
+            'class' => yii\db\Connection::class,
+            'dsn' => 'sqlite:' . \tests\helpers\SqlliteHelper::getTmpFile(),
+        ],
+    ],
+];

--- a/cases/close-connections/fixtures/EmptyFixture.php
+++ b/cases/close-connections/fixtures/EmptyFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace tests\fixtures;
+
+use yii\test\DbFixture;
+
+class EmptyFixture extends DbFixture
+{
+    public function load()
+    {
+    }
+
+    public function unload()
+    {
+    }
+}

--- a/cases/close-connections/functional.suite.yml
+++ b/cases/close-connections/functional.suite.yml
@@ -1,0 +1,8 @@
+actor: FunctionalTester
+modules:
+  enabled:
+    - Yii2
+    - Asserts
+  config:
+    Yii2:
+      cleanup: true

--- a/cases/close-connections/functional/FirstCest.php
+++ b/cases/close-connections/functional/FirstCest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace tests\functional;
+
+use tests\fixtures\EmptyFixture;
+use tests\FunctionalTester;
+use tests\helpers\SqlliteHelper;
+
+class FirstCest
+{
+    public function _fixtures()
+    {
+        return [
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ];
+    }
+
+    public function NoConnections1(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function NoConnections2(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function NoConnections3(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+}

--- a/cases/close-connections/functional/SecondCest.php
+++ b/cases/close-connections/functional/SecondCest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace tests\functional;
+
+use tests\fixtures\EmptyFixture;
+use tests\FunctionalTester;
+use tests\helpers\SqlliteHelper;
+
+class SecondCest
+{
+    public function _before(FunctionalTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+    }
+
+    public function OnlyOneConnection1(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection2(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection3(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+}

--- a/cases/close-connections/functional/ThirdCest.php
+++ b/cases/close-connections/functional/ThirdCest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace tests\functional;
+
+use tests\fixtures\EmptyFixture;
+use tests\FunctionalTester;
+use tests\helpers\SqlliteHelper;
+
+class ThirdCest
+{
+    public function NoConnections1(FunctionalTester $I)
+    {
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(0, $count);
+    }
+
+    public function OnlyOneConnection2(FunctionalTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+
+    public function OnlyOneConnection3(FunctionalTester $I)
+    {
+        $I->haveFixtures([
+            [
+                'class' => EmptyFixture::class,
+            ],
+        ]);
+
+        $count = SqlliteHelper::connectionCount();
+        $I->assertEquals(1, $count);
+    }
+}

--- a/cases/close-connections/helpers/SqlliteHelper.php
+++ b/cases/close-connections/helpers/SqlliteHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace tests\helpers;
+
+class SqlliteHelper
+{
+    protected static $temp_name;
+
+    public static function getTmpFile()
+    {
+        if (empty(self::$temp_name)) {
+            self::$temp_name = tempnam(null, '/file0');
+        }
+        return self::$temp_name;
+    }
+
+    public static function connectionCount()
+    {
+        $path = self::$temp_name;
+        $count = shell_exec("lsof -e /sys/kernel/debug/tracing {$path} | grep {$path} | wc -l");
+        return (int)$count;
+    }
+}

--- a/cases/close-connections/helpers/SqlliteHelper.php
+++ b/cases/close-connections/helpers/SqlliteHelper.php
@@ -17,7 +17,7 @@ class SqlliteHelper
     public static function connectionCount()
     {
         $path = self::$temp_name;
-        $count = shell_exec("lsof -e /sys/kernel/debug/tracing {$path} | grep {$path} | wc -l");
+        $count = shell_exec("lsof {$path} | grep {$path} | wc -l");
         return (int)$count;
     }
 }


### PR DESCRIPTION
Db connections doesn't close if set `cleanup: false` in yml file.
1. Run functional tests where `cleanup: true`. All fine.
`./bin/codecept run -c ./cases/close-connections functional`
2. Run same acceptance tests where `cleanup: false`. Tests failed.
`./bin/codecept run -c ./cases/close-connections acceptance`
3. Run all tests. Functional tests now failed because connections opened by acceptance tests is not closed.
`./bin/codecept run -c ./cases/close-connections`
